### PR TITLE
Change api endpoint to make it compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Run as follows. This will index the L1InfoTree and both L1 + L2 (1=PolygonZKEVM)
 ```
 cargo run -- \
 --l1-rpc-url="https://mainnet.gateway.tenderly.co/YOU_API_KEY" \
---l2-rpc-url="1:https://zkevm-rpc.com"
+--l2-rpc-url="1:https://zkevm-rpc.com" \
+--l2-rpc-url="20:https://rpc.katanarpc.com"
 ```
 
 Mainnet addresses are hardcoded, but you can configure `--ger-address`, `--bridge-address` and `--rollup-manager-address`. For help:
@@ -34,5 +35,5 @@ curl "http://localhost:3000/sync-status"
 
 Get Merkle proofs to claim a deposit.
 ```
-curl "http://localhost:3000/claim-proof?network_id=0&deposit_count=133"
+curl "http://localhost:3000/merkle-proof?deposit_cnt=15&net_id=20"
 ```

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -59,6 +59,8 @@ impl<P: EventProcessor + Send + Sync + 'static> Indexer<P> {
 
         let latest_processed_block = event_processor.latest_processed_block()?;
 
+        println!("[{}] rpc_url: {:?}", name, rpc_url);
+
         println!(
             "[{}] latest_processed_block: {:?}",
             name, latest_processed_block

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .iter()
         .map(|l2_rpc| {
             Indexer::new(
-                l1_rpc_url.clone(),
+                l2_rpc.rpc_url.clone(),
                 format!("l2-bridge-indexer-aggchain-{}", l2_rpc.aggchain_id),
                 bridge_address,
                 BlockNumberOrTag::Latest,


### PR DESCRIPTION
* Change api endpoint to make it compatible with the existing one.
* Now the proofs are fetched as `http://localhost:3000/merkle-proof?deposit_cnt=15&net_id=20`
* And the result is the same as the zkevm-bridge-service.
* Note that it runs on finalized blocks.