### PR TITLE
feat: add configurable block range for indexer queries

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,4 +70,9 @@ pub struct Cli {
     /// Example: 0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2
     #[arg(long, default_value = "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2")]
     pub rollup_manager_address: String,
+
+    /// Number of blocks to query in a single request.
+    /// Lower values help avoid RPC timeouts but may slow down indexing.
+    #[arg(long, default_value = "10000")]
+    pub block_range: u64,
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -46,13 +46,12 @@ impl<P: EventProcessor + Send + Sync + 'static> Indexer<P> {
         contract_address: Address,
         sync_mode: BlockNumberOrTag,
         event_processor: P,
+        block_range: u64,
     ) -> Result<Self, eyre::Report> {
         // TODO: Maybe pass the provider instead of the url to each type?
         let max_retry: u32 = 100;
         let backoff: u64 = 2000;
         let cups: u64 = 100;
-
-        let block_range: u64 = 10_000;
         let parallel_queries: usize = 5;
         let max_queue_size: usize = 100;
         let poll_interval: u64 = 3;

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             tree: Arc::clone(&trees),
             aggchain_id: 0,
         },
+        cli.block_range,
     )?;
 
     // Create one indexer per configured L2 RPC, using aggchain_id in the name
@@ -99,6 +100,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     tree: Arc::clone(&trees),
                     aggchain_id: l2_rpc.aggchain_id,
                 },
+                cli.block_range,
             )
         })
         .collect::<Result<_, _>>()?;
@@ -111,6 +113,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         RollupManagerEventProcessor {
             tree: Arc::clone(&trees),
         },
+        cli.block_range,
     )?;
 
     let l1infotree_indexer = Indexer::new(
@@ -122,6 +125,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             tree: Arc::clone(&trees),
             provider: l1_provider.clone(),
         },
+        cli.block_range,
     )?;
 
     let handle_l1_bridge_indexer = task::spawn(l1_bridge_indexer.run());


### PR DESCRIPTION
- Add --block-range CLI flag with default value of 10000
- Update Indexer::new() to accept block_range parameter
- Pass CLI block_range to all indexer instances

This allows users to configure the number of blocks queried in a single RPC request, helping to avoid timeouts on RPC endpoints with strict limits or when indexing contracts with high event volumes.

Example usage: --block-range 1000