### PR TITLE
Always retry + run on finalized blocks

### DIFF
--- a/src/indexer_rollupmanager.rs
+++ b/src/indexer_rollupmanager.rs
@@ -30,33 +30,15 @@ impl EventProcessor for RollupManagerEventProcessor {
             match event.topic0() {
                 Some(&CreateNewRollup::SIGNATURE_HASH) => {
                     let event = event.log_decode::<CreateNewRollup>()?;
-                    self.tree.set_rollup_leaf(
-                        event.data().rollupID,
-                        &B256::default(),
-                        event
-                            .block_number
-                            .ok_or(eyre::eyre!("Block number not found"))?,
-                    )?;
+                    // TODO:
                 }
                 Some(&AddExistingRollup::SIGNATURE_HASH) => {
                     let event = event.log_decode::<AddExistingRollup>()?;
-                    self.tree.set_rollup_leaf(
-                        event.data().rollupID,
-                        &B256::default(),
-                        event
-                            .block_number
-                            .ok_or(eyre::eyre!("Block number not found"))?,
-                    )?;
+                    // TODO:
                 }
                 Some(&AddExistingRollupOld::SIGNATURE_HASH) => {
                     let event = event.log_decode::<AddExistingRollupOld>()?;
-                    self.tree.set_rollup_leaf(
-                        event.data().rollupID,
-                        &B256::default(),
-                        event
-                            .block_number
-                            .ok_or(eyre::eyre!("Block number not found"))?,
-                    )?;
+                    // TODO:
                 }
                 Some(&VerifyBatchesTrustedAggregator::SIGNATURE_HASH) => {
                     let event = event.log_decode::<VerifyBatchesTrustedAggregator>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         l1_rpc_url.clone(),
         "l1-bridge-indexer".to_string(),
         bridge_address,
-        BlockNumberOrTag::Latest,
+        BlockNumberOrTag::Finalized,
         BridgeEventProcessor {
             tree: Arc::clone(&trees),
             aggchain_id: 0,
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 l2_rpc.rpc_url.clone(),
                 format!("l2-bridge-indexer-aggchain-{}", l2_rpc.aggchain_id),
                 bridge_address,
-                BlockNumberOrTag::Latest,
+                BlockNumberOrTag::Finalized,
                 BridgeEventProcessor {
                     tree: Arc::clone(&trees),
                     aggchain_id: l2_rpc.aggchain_id,
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         l1_rpc_url.clone(),
         "rollup-manager-indexer".to_string(),
         rollup_manager_address,
-        BlockNumberOrTag::Latest,
+        BlockNumberOrTag::Finalized,
         RollupManagerEventProcessor {
             tree: Arc::clone(&trees),
         },
@@ -120,7 +120,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         l1_rpc_url.clone(),
         "l1infotree-indexer".to_string(),
         ger_address,
-        BlockNumberOrTag::Latest,
+        BlockNumberOrTag::Finalized,
         L1InfoTreeEventProcessor {
             tree: Arc::clone(&trees),
             provider: l1_provider.clone(),


### PR DESCRIPTION
* Modify middleware to always retry on RPC failure. Before it only retried on rate limits.
* Modify the indexers to run on finalized blocks. Before it was running on latest.
* Fix bug where ZERO 0x was being inserted in the RER.