### PR TITLE
Store bridge events in sqlite + expose API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ out/
 
 target
 
+sqlite.db
+
 db
+
+rocksdb
 
 **DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ target
 
 sqlite.db
 
+sqlite.db-shm
+sqlite.db-wal
+
 db
 
 rocksdb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,11 @@ dependencies = [
  "eyre",
  "futures",
  "futures-util",
+ "hex",
  "rocksdb",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
 ]
 
@@ -1168,6 +1170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1388,9 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1560,6 +1574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1660,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1734,6 +1766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1818,6 +1851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1929,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2008,17 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -2031,6 +2103,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2187,6 +2270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,12 +2309,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2654,6 +2764,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -2696,6 +2809,17 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "zstd-sys",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2774,6 +2898,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2983,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,6 +3011,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3004,6 +3166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3199,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3090,6 +3267,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -3417,6 +3605,26 @@ checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3865,6 +4073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,6 +4089,196 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.3",
+ "hashlink",
+ "indexmap 2.9.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.101",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.12",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3885,6 +4292,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4103,6 +4521,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4339,10 +4772,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-xid"
@@ -4455,6 +4909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,6 +5019,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4645,6 +5115,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4659,6 +5138,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4695,6 +5189,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4707,6 +5207,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4716,6 +5222,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4743,6 +5255,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4752,6 +5270,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4767,6 +5291,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4776,6 +5306,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ async-trait = "0.1.88"
 clap = { version = "4.0", features = ["derive"] }
 
 axum = "0.8.4"
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite"] }
+hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Proof of concept implementation of aggkit in Rust. Barely tested and not meant for production use.
 
-## Features
+## Features
 
 Covered features:
 - [x] aggbridge
+- [x] l1infotree indexer
 - [ ] aggsender
 - [ ] aggoracle
 
@@ -16,7 +17,7 @@ Important stuff:
 * Stores bridge exits in an SQLite database.
 * Allows indexing an arbitrary number of chains. Pass as many `--l2-rpc-url` as you like.
 
-## Run
+## Run
 
 Run as follows. This will index the L1InfoTree and both L1 + L2 (1=PolygonZKEVM) bridges. It does so in around 8 minutes.
 ```
@@ -42,24 +43,31 @@ curl "http://localhost:3000/sync-status"
 ```
 
 `merkle-proof`
+
 Get Merkle proofs to claim a deposit.
 ```
 curl "http://localhost:3000/merkle-proof?deposit_cnt=15&net_id=20"
 ```
 
 `bridges`
-Get the bridge exits.
 
-```
-curl -s "http://localhost:3000/bridges"
-```
+Get the bridge exits of a given network. Note that the `network_id` parameter is mandatory.
 
+Get all bridge events that started in `network_id=0`. It returns an array with them in `deposits` and `total_cnt`. See paging.
 ```
-curl -s "http://localhost:3000/bridges?orig_addr=0x2C24B57e2CCd1f273045Af6A5f632504C432374F"
+curl "http://localhost:3000/bridges?network_id=0"
 ```
 
-// TODO: add paging.
+You can use paging as follows. The `deposit_cnt` is used for ordering, ascending.
 
-its destination address.
-https://bridge-api.zkevm-rpc.com/bridges/0xCE27d8BCee45dB3E457EcF8629264Ca7893AAaAc?tx_hash=0xb6d5b7c68c0fe03296f40d5338749169810d7b0cbfc056dbd2425201cbe1f7bc
+```
+curl "http://localhost:3000/bridges?network_id=0&page_number=1&page_size=2"
+```
 
+Get all bridges with a given origin_addr.
+
+```
+curl "http://localhost:3000/bridges?network_id=0&dest_addr=0xCE27d8BCee45dB3E457EcF8629264Ca7893AAaAc"
+```
+
+All the fields present in the response can be used for filtering.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Proof of concept implementation of aggkit in Rust. Barely tested and not meant for production use.
 
+## Features
+
 Covered features:
 - [x] aggbridge
 - [ ] aggsender
@@ -10,9 +12,11 @@ Covered features:
 Important stuff:
 * Uses alloy v1.
 * Heavily parallelizes event indexing using async tokio.
-* Stores bridge exits in a key-value db. All intermediate levels are prehashed, which should allow for really fast lookups.
+* Stores bridge exits in a key-value db. All intermediate levels are prehashed, which allows for really fast lookups for merkle proofs of the local exit root and rollup exit root.
+* Stores bridge exits in an SQLite database.
 * Allows indexing an arbitrary number of chains. Pass as many `--l2-rpc-url` as you like.
 
+## Run
 
 Run as follows. This will index the L1InfoTree and both L1 + L2 (1=PolygonZKEVM) bridges. It does so in around 8 minutes.
 ```
@@ -27,13 +31,35 @@ Mainnet addresses are hardcoded, but you can configure `--ger-address`, `--bridg
 cargo run -- --help
 ```
 
+## API Docs
+
+
+`sync-status`
+
 Check sync status.
 ```
 curl "http://localhost:3000/sync-status"
 ```
 
-
+`merkle-proof`
 Get Merkle proofs to claim a deposit.
 ```
 curl "http://localhost:3000/merkle-proof?deposit_cnt=15&net_id=20"
 ```
+
+`bridges`
+Get the bridge exits.
+
+```
+curl -s "http://localhost:3000/bridges"
+```
+
+```
+curl -s "http://localhost:3000/bridges?orig_addr=0x2C24B57e2CCd1f273045Af6A5f632504C432374F"
+```
+
+// TODO: add paging.
+
+its destination address.
+https://bridge-api.zkevm-rpc.com/bridges/0xCE27d8BCee45dB3E457EcF8629264Ca7893AAaAc?tx_hash=0xb6d5b7c68c0fe03296f40d5338749169810d7b0cbfc056dbd2425201cbe1f7bc
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -201,8 +201,8 @@ async fn claim_proof(
 
 #[derive(Serialize)]
 pub struct BridgesResult {
-    pub bridges: Vec<BridgeRecord>,
-    pub count: i64,
+    pub deposits: Vec<BridgeRecord>,
+    pub total_cnt: i64,
 }
 
 async fn get_bridges(
@@ -211,7 +211,11 @@ async fn get_bridges(
 ) -> impl IntoResponse {
     // TODO: If the request is for a network_id not being indexed, error out.
     match state.db.get_bridges(params).await {
-        Ok((bridges, count)) => axum::Json(BridgesResult { bridges, count }).into_response(),
+        Ok((deposits, total_cnt)) => axum::Json(BridgesResult {
+            deposits,
+            total_cnt,
+        })
+        .into_response(),
         Err(err) => {
             eprintln!("Error retrieving bridges: {err}");
             (

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use crate::contracts::PolygonZkEVMBridgeV2::PolygonZkEVMBridgeV2Instance;
 use crate::contracts::PolygonZkEVMGlobalExitRootV2::PolygonZkEVMGlobalExitRootV2Instance;
+use crate::db::{BridgeFilters, BridgeRecord, Database};
 use crate::merkle_tree::MerkleForest;
 use crate::merkle_tree::TreeType;
 use alloy::primitives::B256;
@@ -70,6 +71,7 @@ pub struct AppState {
     pub l1_bridge: PolygonZkEVMBridgeV2Instance<ProviderStack>,
     pub l2_bridges: HashMap<u32, PolygonZkEVMBridgeV2Instance<ProviderStack>>,
     pub l1_infotree: PolygonZkEVMGlobalExitRootV2Instance<ProviderStack>,
+    pub db: Database,
     //pub rollup_manager: PolygonRollupManagerInstance<ProviderStack>, Not needed?
 }
 
@@ -197,11 +199,36 @@ async fn claim_proof(
     axum::Json(response)
 }
 
+#[derive(Serialize)]
+pub struct BridgesResult {
+    pub bridges: Vec<BridgeRecord>,
+    pub count: i64,
+}
+
+async fn get_bridges(
+    State(state): State<AppState>,
+    Query(params): Query<BridgeFilters>,
+) -> impl IntoResponse {
+    // TODO: If the request is for a network_id not being indexed, error out.
+    match state.db.get_bridges(params).await {
+        Ok((bridges, count)) => axum::Json(BridgesResult { bridges, count }).into_response(),
+        Err(err) => {
+            eprintln!("Error retrieving bridges: {err}");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            )
+                .into_response()
+        }
+    }
+}
+
 pub async fn run_server(state: AppState) -> Result<(), Box<dyn Error + Send + Sync>> {
     let server_task = tokio::spawn(async move {
         let app = Router::new()
             .route("/sync-status", get(sync_status))
             .route("/merkle-proof", get(claim_proof))
+            .route("/bridges", get(get_bridges))
             .with_state(state);
 
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,8 +53,13 @@ pub struct Cli {
 
     /// Path for the key-value store storing the merkle tree.
     /// Example: db
-    #[arg(long, default_value = "db")]
+    #[arg(long, default_value = "rocksdb")]
     pub key_value_store: String,
+
+    /// Path for the SQLite database storing the bridge events.
+    /// Example: sqlite://bridge_events.db
+    #[arg(long, default_value = "sqlite://sqlite.db")]
+    pub db_path: String,
 
     /// Contract address of the PolygonZkEVMGlobalExitRootV2.
     /// Example: 0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,13 +28,17 @@ impl Database {
 
         let db = SqlitePool::connect(database_url).await.unwrap();
 
+        // Create tables if they don't exist yet.
+        let db = Self { pool: Arc::new(db) };
+        db.create_tables().await?;
+
         /* TODO: Have a look into this.
         let pool = SqlitePoolOptions::new()
             .max_connections(5)
             .connect(database_url)
             .await?;*/
 
-        Ok(Self { pool: Arc::new(db) })
+        Ok(db)
     }
 
     // TODO: Unoptimized, create INDEX, etc.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,374 @@
+use crate::contracts::PolygonZkEVMBridgeV2::BridgeEvent;
+use alloy::primitives::Log as LogPrimitive;
+use alloy::primitives::keccak256;
+use alloy::rpc::types::Log;
+use hex;
+use serde::{Deserialize, Serialize};
+use sqlx::QueryBuilder;
+use sqlx::{Sqlite, SqlitePool, migrate::MigrateDatabase};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Database {
+    pool: Arc<SqlitePool>,
+}
+
+impl Database {
+    // Create a new SQLite database (file) and ensure the required table exists.
+    pub async fn new(database_url: &str) -> Result<Self, eyre::Error> {
+        if !Sqlite::database_exists(database_url).await.unwrap_or(false) {
+            println!("Creating database {}", database_url);
+            match Sqlite::create_database(database_url).await {
+                Ok(_) => println!("Create db success"),
+                Err(error) => panic!("error: {}", error),
+            }
+        } else {
+            println!("Database already exists");
+        }
+
+        let db = SqlitePool::connect(database_url).await.unwrap();
+
+        /* TODO: Have a look into this.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(database_url)
+            .await?;*/
+
+        Ok(Self { pool: Arc::new(db) })
+    }
+
+    // TODO: Unoptimized, create INDEX, etc.
+    pub async fn create_tables(&self) -> Result<(), eyre::Error> {
+        // Create table if it doesn't exist yet. Adjust types as needed.
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS bridge_events (
+                id TEXT PRIMARY KEY,
+                leaf_type INTEGER,
+                orig_net INTEGER,
+                orig_addr TEXT,
+                amount TEXT,
+                dest_net INTEGER,
+                dest_addr TEXT,
+                block_num INTEGER,
+                deposit_cnt INTEGER,
+                network_id INTEGER,
+                tx_hash TEXT,
+                claim_tx_hash TEXT,
+                metadata TEXT,
+                ready_for_claim INTEGER,
+                global_index INTEGER
+            );
+            "#,
+        )
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn insert_bridge_event(
+        &self,
+        event: &Log<BridgeEvent>,
+        network_id: u32,
+    ) -> Result<(), eyre::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO bridge_events (
+                id,
+                leaf_type,
+                orig_net,
+                orig_addr,
+                amount,
+                dest_net,
+                dest_addr,
+                block_num,
+                deposit_cnt,
+                network_id,
+                tx_hash,
+                claim_tx_hash,
+                metadata,
+                ready_for_claim,
+                global_index
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            "#,
+        )
+        .bind(calculate_id(network_id, event.data().depositCount))
+        .bind(&event.data().leafType)
+        .bind(&event.data().originNetwork)
+        .bind(&event.data().originAddress.to_string())
+        .bind(&event.data().amount.to_string())
+        .bind(&event.data().destinationNetwork)
+        .bind(&event.data().destinationAddress.to_string())
+        .bind(
+            event
+                .block_number
+                .ok_or_else(|| eyre::eyre!("Block number is None"))? as i64,
+        )
+        .bind(&event.data().depositCount)
+        .bind(network_id)
+        .bind(
+            event
+                .transaction_hash
+                .ok_or_else(|| eyre::eyre!("Transaction hash is None"))?
+                .to_string(),
+        )
+        .bind("0xnot_implemented") // TODO: Not implemented.
+        .bind(&event.data().metadata.to_string())
+        .bind(0) // TODO: Not implemented.
+        .bind(0) // TODO: Not implemented
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_bridges(
+        &self,
+        filters: BridgeFilters,
+    ) -> Result<(Vec<BridgeRecord>, i64), eyre::Error> {
+        // Default pagination values
+        let page_size = filters.page_size.unwrap_or(50).clamp(1, 1000);
+        let page_number = filters.page_number.unwrap_or(1).max(1);
+        let offset = (page_number - 1) * page_size;
+
+        // Always filter by `network_id` first; additional filters are appended.
+        let mut qb: QueryBuilder<sqlx::Sqlite> =
+            QueryBuilder::new("SELECT * FROM bridge_events WHERE network_id = ");
+
+        // Always filter by network_id first.
+        qb.push_bind(filters.network_id as i64);
+
+        // Append any optional filters.
+        apply_filters(&mut qb, &filters);
+
+        // ORDER BY deposit_cnt ascending
+        qb.push(" ORDER BY deposit_cnt ASC");
+
+        // Apply pagination
+        qb.push(" LIMIT ")
+            .push_bind(page_size)
+            .push(" OFFSET ")
+            .push_bind(offset);
+
+        let bridges: Vec<BridgeRecord> = qb.build_query_as().fetch_all(&*self.pool).await?;
+
+        // Count query. Same query to count total number of rows. For pagination.
+        let mut qb_cnt: QueryBuilder<sqlx::Sqlite> =
+            QueryBuilder::new("SELECT COUNT(*) as cnt FROM bridge_events WHERE network_id = ");
+        qb_cnt.push_bind(filters.network_id as i64);
+
+        // Re-use the same optional filters for the count query.
+        apply_filters(&mut qb_cnt, &filters);
+
+        let count: (i64,) = qb_cnt.build_query_as().fetch_one(&*self.pool).await?;
+
+        Ok((bridges, count.0))
+    }
+}
+
+// The id field of the bridge_events table is a unique identifier for the bridge event.
+// It is a hash of the network_id and deposit_cnt.
+// TODO: Unsure if there are performance penalties if using a STRING as primary key.
+fn calculate_id(network_id: u32, deposit_cnt: u32) -> String {
+    let mut buf = [0u8; 8];
+    buf[..4].copy_from_slice(&network_id.to_be_bytes());
+    buf[4..].copy_from_slice(&deposit_cnt.to_be_bytes());
+
+    let hash = keccak256(&buf);
+    format!("0x{}", hex::encode(hash.as_slice()))
+}
+
+fn apply_filters<'qb>(qb: &mut QueryBuilder<'qb, Sqlite>, f: &'qb BridgeFilters) {
+    macro_rules! add {
+        ($opt:expr, $col:literal) => {
+            if let Some(ref v) = $opt {
+                qb.push(" AND ").push($col).push(" = ").push_bind(v);
+            }
+        };
+    }
+
+    add!(f.leaf_type, "leaf_type");
+    add!(f.orig_net, "orig_net");
+    add!(f.orig_addr, "orig_addr");
+    add!(f.amount, "amount");
+    add!(f.dest_net, "dest_net");
+    add!(f.dest_addr, "dest_addr");
+    add!(f.block_num, "block_num");
+    add!(f.deposit_cnt, "deposit_cnt");
+    add!(f.tx_hash, "tx_hash");
+    add!(f.claim_tx_hash, "claim_tx_hash");
+    add!(f.metadata, "metadata");
+    if let Some(b) = f.ready_for_claim {
+        qb.push(" AND ready_for_claim = ").push_bind(b as i32);
+    }
+    add!(f.global_index, "global_index");
+}
+
+#[derive(Serialize, Clone, sqlx::FromRow, Debug)]
+pub struct BridgeRecord {
+    pub leaf_type: i64,
+    pub orig_net: i64,
+    pub orig_addr: String,
+    pub amount: String,
+    pub dest_net: i64,
+    pub dest_addr: String,
+    pub block_num: i64,
+    pub deposit_cnt: i64,
+    pub network_id: u32,
+    pub tx_hash: String,
+    pub claim_tx_hash: String,
+    pub metadata: String,
+    pub ready_for_claim: bool,
+    pub global_index: i64,
+}
+
+#[derive(Deserialize, Debug, Clone, Serialize)]
+pub struct BridgeFilters {
+    // Pagination
+    pub page_number: Option<i64>,
+    pub page_size: Option<i64>,
+
+    // Mandatory filter
+    pub network_id: u32,
+
+    // Optional filters. All correspond to column names
+    pub leaf_type: Option<i64>,
+    pub orig_net: Option<i64>,
+    pub orig_addr: Option<String>,
+    pub amount: Option<String>,
+    pub dest_net: Option<i64>,
+    pub dest_addr: Option<String>,
+    pub block_num: Option<i64>,
+    pub deposit_cnt: Option<i64>,
+    pub tx_hash: Option<String>,
+    pub claim_tx_hash: Option<String>,
+    pub metadata: Option<String>,
+    pub ready_for_claim: Option<bool>,
+    pub global_index: Option<i64>,
+}
+
+impl Default for BridgeFilters {
+    fn default() -> Self {
+        Self {
+            page_number: None,
+            page_size: None,
+            network_id: 0,
+            leaf_type: None,
+            orig_net: None,
+            orig_addr: None,
+            amount: None,
+            dest_net: None,
+            dest_addr: None,
+            block_num: None,
+            deposit_cnt: None,
+            tx_hash: None,
+            claim_tx_hash: None,
+            metadata: None,
+            ready_for_claim: None,
+            global_index: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::B256;
+    use alloy::primitives::Bytes;
+    use alloy::primitives::address;
+    use alloy::uint;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_bridges() {
+        // Create a new in-memory database with the required tables.
+        let db = Database::new("sqlite::memory:").await.unwrap();
+        db.create_tables().await.unwrap();
+
+        // Insert a bunch of bridge events (see depositCount)
+        let network_id = 0u32;
+        for i in 0..10 {
+            let log = Log::<BridgeEvent> {
+                inner: LogPrimitive {
+                    address: address!("0x1111111111111111111111111111111111111111"),
+                    data: BridgeEvent {
+                        leafType: 1,
+                        originNetwork: 0,
+                        originAddress: address!("0x1111111111111111111111111111111111111111"),
+                        destinationNetwork: 2,
+                        destinationAddress: address!("0x2222222222222222222222222222222222222222"),
+                        amount: uint!(6_666_666_U256),
+                        metadata: Bytes::from_static(b"some metadata"),
+                        // -> Set an increasing deposit count.
+                        depositCount: i,
+                    },
+                },
+                block_hash: Some(B256::ZERO),
+                block_number: Some(0),
+                block_timestamp: None,
+                transaction_hash: Some(B256::ZERO),
+                transaction_index: Some(0),
+                log_index: Some(0),
+                removed: false,
+            };
+            db.insert_bridge_event(&log, network_id).await.unwrap();
+        }
+
+        // Test 1. Get a single bridge event by deposit count.
+        {
+            let filters = BridgeFilters {
+                // -> filter by deposit count.
+                deposit_cnt: Some(5),
+                network_id: network_id,
+                // Defaults to None.
+                ..Default::default()
+            };
+
+            let (bridges, count) = db.get_bridges(filters).await.unwrap();
+            assert_eq!(bridges.len(), 1);
+            assert_eq!(count, 1);
+            assert_eq!(bridges[0].deposit_cnt, 5);
+        }
+
+        // Test 2. Get all bridge events using pagination. First page. 5/10
+        {
+            let filters = BridgeFilters {
+                // -> page 1
+                page_number: Some(1),
+                page_size: Some(5),
+                network_id: network_id,
+                // Defaults to None.
+                ..Default::default()
+            };
+            let (bridges, count) = db.get_bridges(filters).await.unwrap();
+            assert_eq!(bridges.len(), 5);
+            assert_eq!(count, 10);
+            assert_eq!(bridges[0].deposit_cnt, 0);
+            assert_eq!(bridges[1].deposit_cnt, 1);
+            assert_eq!(bridges[2].deposit_cnt, 2);
+            assert_eq!(bridges[3].deposit_cnt, 3);
+            assert_eq!(bridges[4].deposit_cnt, 4);
+        }
+
+        // Test 3. Get all bridge events using pagination. Second page. 5/10
+        {
+            let filters = BridgeFilters {
+                // -> page 2
+                page_number: Some(2),
+                page_size: Some(5),
+                network_id: network_id,
+                // Defaults to None.
+                ..Default::default()
+            };
+            let (bridges, count) = db.get_bridges(filters).await.unwrap();
+            assert_eq!(bridges.len(), 5);
+            assert_eq!(count, 10);
+            assert_eq!(bridges[0].deposit_cnt, 5);
+            assert_eq!(bridges[1].deposit_cnt, 6);
+            assert_eq!(bridges[2].deposit_cnt, 7);
+            assert_eq!(bridges[3].deposit_cnt, 8);
+            assert_eq!(bridges[4].deposit_cnt, 9);
+        }
+    }
+}

--- a/src/indexer_bridge.rs
+++ b/src/indexer_bridge.rs
@@ -1,4 +1,5 @@
 use crate::contracts::PolygonZkEVMBridgeV2::{BridgeEvent, ClaimEvent, NewWrappedToken};
+use crate::db::Database;
 use crate::indexer::EventProcessor;
 use crate::leaf_bridge::LeafBridge;
 use crate::merkle_tree::{MerkleForest, TreeType};
@@ -6,11 +7,13 @@ use alloy::rpc::types::Log;
 use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use eyre::Result;
+
 use std::sync::Arc;
 
 pub struct BridgeEventProcessor {
     pub tree: Arc<MerkleForest>,
     pub aggchain_id: u32,
+    pub db: Database,
 }
 
 #[async_trait]
@@ -27,6 +30,10 @@ impl EventProcessor for BridgeEventProcessor {
                     let event = event.log_decode::<BridgeEvent>()?;
                     let leaf_bridge = LeafBridge::new(event.data().clone());
 
+                    // TODO: Ugly assumption. We assume bridge exits here are inserted
+                    // atomically in the tree (key-value) and in the sqlite database. The one ruling
+                    // up to which block we processed, is the key-value store. Fix this.
+
                     // TODO: Ensure the block number is updated only when there are no more events from that block.
                     // TODO: Process in batches instead of one by one.
                     self.tree.append_events(
@@ -36,6 +43,11 @@ impl EventProcessor for BridgeEventProcessor {
                             .block_number
                             .ok_or(eyre::eyre!("Block number is None"))?,
                     )?;
+
+                    // TODO: Do batch inserts as well.
+                    self.db
+                        .insert_bridge_event(&event, self.aggchain_id)
+                        .await?;
                 }
                 Some(&ClaimEvent::SIGNATURE_HASH) => {
                     let event = event.log_decode::<ClaimEvent>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod cli;
 pub mod contracts;
+pub mod db;
 pub mod indexer;
 pub mod indexer_bridge;
 pub mod indexer_l1infotree;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use aggkit_rust::api::{AppState, ProviderStack, run_server};
 use aggkit_rust::cli::Cli;
 use aggkit_rust::contracts::PolygonZkEVMBridgeV2::{self, PolygonZkEVMBridgeV2Instance};
 use aggkit_rust::contracts::{PolygonRollupManager, PolygonZkEVMGlobalExitRootV2};
+use aggkit_rust::db::Database;
 use aggkit_rust::indexer::Indexer;
 use aggkit_rust::indexer_bridge::BridgeEventProcessor;
 use aggkit_rust::indexer_l1infotree::L1InfoTreeEventProcessor;
@@ -72,6 +73,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         rollup_manager_address
     );
 
+    let db = Database::new(&cli.db_path).await?;
     let trees = Arc::new(MerkleForest::open(key_value_store)?);
 
     let l1_bridge_indexer = Indexer::new(
@@ -82,6 +84,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         BridgeEventProcessor {
             tree: Arc::clone(&trees),
             aggchain_id: 0,
+            db: db.clone(),
         },
         cli.block_range,
     )?;
@@ -99,6 +102,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 BridgeEventProcessor {
                     tree: Arc::clone(&trees),
                     aggchain_id: l2_rpc.aggchain_id,
+                    db: db.clone(),
                 },
                 cli.block_range,
             )
@@ -169,6 +173,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         l1_bridge: l1_bridge,
         l2_bridges: l2_bridges,
         l1_infotree: l1_infotree,
+        db: db.clone(),
         //rollup_manager: rollup_manager,
     };
     let handle_api = task::spawn(run_server(state));


### PR DESCRIPTION
* Stores bridge events in an sqlite database.
* Exposes a new API endpoint `/bridges` that allows to fetch bridge exits filtering by any field and with support for paging. See docs in README.md.
* New CLI flag with sqlite db path.
* Important: Clear all db files to migrate to this.